### PR TITLE
Implement missing event - OnPlayerOpenedContainer

### DIFF
--- a/container-dialog.inc
+++ b/container-dialog.inc
@@ -198,6 +198,8 @@ stock DisplayContainerInventory(playerid, Container:containerid) {
 	}
 	Dialog_ShowCallback(playerid, using inline Response, DIALOG_STYLE_LIST, title, cnt_InventoryString[playerid], "Options", "Close");
 
+	CallLocalFunction("OnPlayerOpenedContainer", "dd", playerid, _:containerid)
+
 	return 0;
 }
 


### PR DESCRIPTION
Looks like a forgotten event. It's mentioned in the "Even API" section of the file but I don't see it being implemented.