### PR TITLE
Fix warning 208 on latest YSI

### DIFF
--- a/container-dialog.inc
+++ b/container-dialog.inc
@@ -391,6 +391,10 @@ hook OnPlayerViewInvOpt(playerid) {
 	return 0;
 }
 
+timer _container_showInv[0](playerid) {
+	DisplayPlayerInventory(playerid);
+}
+
 hook OnPlayerSelectInvOpt(playerid, option) {
 	if(cnt_CurrentContainer[playerid] != INVALID_CONTAINER_ID) {
 		if(option == cnt_InventoryOptionID[playerid]) {
@@ -425,10 +429,6 @@ hook OnPlayerSelectInvOpt(playerid, option) {
 	}
 
 	return 0;
-}
-
-timer _container_showInv[0](playerid) {
-	DisplayPlayerInventory(playerid);
 }
 
 hook OnPlayerOpenInventory(playerid) {


### PR DESCRIPTION
y_timers timers are tagged in latest YSI, so calling the timer before declaring its function causes warning 208.